### PR TITLE
Add option to show line numbers in code blocks

### DIFF
--- a/MacDown/Code/Extension/hoedown_html_patch.c
+++ b/MacDown/Code/Extension/hoedown_html_patch.c
@@ -29,7 +29,12 @@ void hoedown_patch_render_blockcode(
         hoedown_buffer *mapped = NULL;
         if (extra->language_addition)
             mapped = extra->language_addition(lang, extra->owner);
-        HOEDOWN_BUFPUTSL(ob, "<pre class=\"line-numbers\"><code class=\"language-");
+
+        if (extra->blockcode_flags & HOEDOWN_BLOCKCODE_LINE_NUMBERS)
+            HOEDOWN_BUFPUTSL(ob, "<pre class=\"line-numbers\">");
+        else
+            HOEDOWN_BUFPUTSL(ob, "<pre>");
+        HOEDOWN_BUFPUTSL(ob, "<code class=\"language-");
         if (mapped)
         {
             hoedown_escape_html(ob, mapped->data, mapped->size, 0);

--- a/MacDown/Code/Extension/hoedown_html_patch.h
+++ b/MacDown/Code/Extension/hoedown_html_patch.h
@@ -11,6 +11,11 @@
 
 static unsigned int HOEDOWN_HTML_USE_TASK_LIST = (1 << 4);
 
+typedef enum hoedown_blockcode_flags {
+    // show line numbers in code blocks
+    HOEDOWN_BLOCKCODE_LINE_NUMBERS = (1 << 0)
+} hoedown_blockcode_flags;
+
 typedef struct hoedown_buffer hoedown_buffer;
 
 typedef struct hoedown_html_renderer_state_extra {
@@ -18,6 +23,7 @@ typedef struct hoedown_html_renderer_state_extra {
     /* More extra callbacks */
     hoedown_buffer *(*language_addition)(const hoedown_buffer *language,
                                          void *owner);
+    hoedown_blockcode_flags blockcode_flags;
     void *owner;
 
 } hoedown_html_renderer_state_extra;


### PR DESCRIPTION
For #246, I had started the work a few months ago and finally got around to updating the code. This will always add the required "line-numbers" classname to code blocks and conditionally include the prism line numbers plugin js and css based on a new preference option under syntax highlighting. I'm new to Apple dev, so apologies if the edits to the html preferences xib cause issues.