### PR TITLE
Update MPDocument.m

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -941,7 +941,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     NSRect editorFrame = self.editor.frame;
     if (editorFrame.size.width != clipWidth)
     {
-        editorFrame.size.width = clipWidth;
+        editorFrame.size.width = round(clipWidth);
         self.editor.frame = editorFrame;
     }
     [self syncScrollers];


### PR DESCRIPTION
This is the bug fix for erratic scrolling in retina Mac Books.