### PR TITLE
Corrected Syntax highlighting for $ and $$ math mode

### DIFF
--- a/Dependency/peg-markdown-highlight/pmh_grammar.leg
+++ b/Dependency/peg-markdown-highlight/pmh_grammar.leg
@@ -390,6 +390,7 @@ Inline  = Str
         | Endline
         | UlOrStarLine
         | Space
+        | Math
         | Strong
         | Emph
         | Image
@@ -621,7 +622,7 @@ Nonspacechar =  !Spacechar !Newline .
 Newline =       '\n' | '\r' '\n'?
 Sp =            Spacechar*
 Spnl =          Sp (Newline Sp)?
-SpecialChar =   '*' | '_' | '`' | '&' | '[' | ']' | '(' | ')' | '<' | '!' | '#' | '\\' | '\'' | '"' | '~' | ExtendedSpecialChar
+SpecialChar =   '$' | '*' | '_' | '`' | '&' | '[' | ']' | '(' | ')' | '<' | '!' | '#' | '\\' | '\'' | '"' | '~' | ExtendedSpecialChar
 NormalChar =    !( SpecialChar | Spacechar | Newline ) .
 # Not used anywhere in grammar:
 #NonAlphanumeric = [\000-\057\072-\100\133-\140\173-\177]
@@ -674,6 +675,15 @@ InlineNote =    &{ EXT(pmh_EXT_NOTES) }
 
 RawNoteBlock =  ( !BlankLine OptionallyIndentedLine )+
                 ( BlankLine* )
+
+
+# Addon for math
+# either do nothing with math (pmh_NO_TYPE) or highlight it as code (pmh_CODE)
+# so that there is no wrong highlighing within MATH
+Math = Dollar1Math | Dollar2Math
+
+Dollar1Math = < "$" ( !'$' . )+ "$" > { ADD(elem(pmh_CODE)); }
+Dollar2Math = < "$$" (!'$' .)+ "$$" > { ADD(elem(pmh_CODE)); }
 
 %%
 


### PR DESCRIPTION
As in the screenshot below syntax highlighting goes a bit wonky sometimes when encountering a math block ($, $$), but it is still rendered correctly. This is because the markdown standard and therefore the peg-markdown-highlight have no concept of math mode.
![screen shot 2015-03-02 at 14 14 48](https://cloud.githubusercontent.com/assets/289544/6441290/d4a10204-c0e6-11e4-922c-d91ff5019ae0.png)

As a fix I just added the syntax for $ and $$ in the .leg file describing syntax to peg-markdown-highlight. This is not an ideal fix as the code for peg-markdown-highlight is a hard copy in the repository. On the other hand it might not be needed upstream as this is not in the Markdown standard and just needed for the editor.

I changed math to render with the code-syntax highlighting as this seems the most natural. It could imply be changed to pmh_NO_TYPE in order not to have syntax highlighting. (or a own type could be added)

Fixed version:
![screen shot 2015-03-02 at 14 15 17](https://cloud.githubusercontent.com/assets/289544/6441291/d4a285ca-c0e6-11e4-8c5b-61457ebbabcb.png)