### PR TITLE
Fix a style & script name for searching plugin directory

### DIFF
--- a/MacDown/Code/Document/MPRenderer.m
+++ b/MacDown/Code/Document/MPRenderer.m
@@ -297,9 +297,12 @@ static void MPFreeHTMLRenderer(hoedown_renderer *htmlRenderer)
     if (self.rendererFlags & HOEDOWN_HTML_BLOCKCODE_LINE_NUMBERS)
     {
         NSBundle *bundle = [NSBundle mainBundle];
-        NSURL *url = [bundle URLForResource:@"line-numbers/prism-line-numbers"
+        NSString *kLineNumbersDirectory = [NSString stringWithFormat:@"%@/%@",
+                                           kMPPrismPluginDirectory,
+                                           @"line-numbers"];
+        NSURL *url = [bundle URLForResource:@"prism-line-numbers"
                               withExtension:@"css"
-                               subdirectory:kMPPrismPluginDirectory];
+                               subdirectory:kLineNumbersDirectory];
         [stylesheets addObject:[MPStyleSheet CSSWithURL:url]];
     }
 
@@ -321,9 +324,12 @@ static void MPFreeHTMLRenderer(hoedown_renderer *htmlRenderer)
 
     if (self.rendererFlags & HOEDOWN_HTML_BLOCKCODE_LINE_NUMBERS)
     {
+        NSString *kLineNumbersDirectory = [NSString stringWithFormat:@"%@/%@",
+                                           kMPPrismPluginDirectory,
+                                           @"line-numbers"];
         NSURL *url =
-            [bundle URLForResource:@"line-numbers/prism-line-numbers.min"
-                     withExtension:@"js" subdirectory:kMPPrismPluginDirectory];
+            [bundle URLForResource:@"prism-line-numbers.min"
+                     withExtension:@"js" subdirectory:kLineNumbersDirectory];
         [scripts addObject:[MPScript javaScriptWithURL:url]];
     }
     return scripts;


### PR DESCRIPTION
following error messages occurred when enable the 'Show line numbers' option and freeze, crash.(only my environment?)
In my thoughts, this problem caused by 'URLForResource' function specified name which contains sub-directory.
Probably, #344 is same problem...?
 my environments is OS X 10.9.5 & applied security update Apr 10th 2015.

```
4/10/15 16:37:13.726 ReportCrash[25141]: com.apple.message.domain: com.apple.crashreporter.writereport.crash
com.apple.message.signature: MacDown
com.apple.message.signature2: com.uranusjr.macdown ||| 0.4.4.1 (624)
com.apple.message.signature3: 1B8D5D9A9C899C7E5FFD18D8D30A696E
com.apple.message.result: YES
com.apple.message.summarize: YES
Sender_Mach_UUID: 3C9D65AC-CCF7-32B3-AE41-F8475197DE30

2015-04-12 18:01:41.310 MacDown[86962:303] *** setObjectForKey: object cannot be nil (key: url)
2015-04-12 18:01:41.311 MacDown[86962:303] (
	0   CoreFoundation                      0x00007fff86de525c __exceptionPreprocess + 172
	1   libobjc.A.dylib                     0x00007fff8aa21e75 objc_exception_throw + 43
	2   CoreFoundation                      0x00007fff86ce022e -[__NSDictionaryM setObject:forKey:] + 1102
	3   MacDown                             0x0000000100013ea1 -[MPAsset htmlForOption:] + 785
	4   MacDown                             0x000000010001abe7 MPGetHTML + 615
	5   MacDown                             0x000000010001a823 -[MPRenderer render] + 275
	6   MacDown                             0x0000000100019676 __33-[MPRenderer parseAndRenderLater]_block_invoke + 38
	7   MacDown                             0x0000000100019dcb -[MPRenderer parse] + 1147
	8   Foundation                          0x00007fff8a3e0714 __NSFireTimer + 96
	9   CoreFoundation                      0x00007fff86d4c3e4 __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 20
	10  CoreFoundation                      0x00007fff86d4bf1f __CFRunLoopDoTimer + 1151
	11  CoreFoundation                      0x00007fff86dbd5aa __CFRunLoopDoTimers + 298
	12  CoreFoundation                      0x00007fff86d076a5 __CFRunLoopRun + 1525
	13  CoreFoundation                      0x00007fff86d06e75 CFRunLoopRunSpecific + 309
	14  HIToolbox                           0x00007fff93805a0d RunCurrentEventLoopInMode + 226
	15  HIToolbox                           0x00007fff938057b7 ReceiveNextEventCommon + 479
	16  HIToolbox                           0x00007fff938055bc _BlockUntilNextEventMatchingListInModeWithFilter + 65
	17  AppKit                              0x00007fff8d6f124e _DPSNextEvent + 1434
	18  AppKit                              0x00007fff8d6f089b -[NSApplication nextEventMatchingMask:untilDate:inMode:dequeue:] + 122
	19  AppKit                              0x00007fff8d6e499c -[NSApplication run] + 553
	20  AppKit                              0x00007fff8d6cf783 NSApplicationMain + 940
	21  MacDown                             0x000000010000be82 main + 34
	22  libdyld.dylib                       0x00007fff89af55fd start + 1
	23  ???                                 0x0000000000000003 0x0 + 3
)
```