### PR TITLE
Fix spelling within Preferences -> Rendering

### DIFF
--- a/MacDown/Localization/Base.lproj/MPHtmlPreferencesViewController.xib
+++ b/MacDown/Localization/Base.lproj/MPHtmlPreferencesViewController.xib
@@ -200,7 +200,7 @@
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vVI-g8-EhH">
                     <rect key="frame" x="106" y="246" width="93" height="14"/>
-                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Accesory:" id="wNy-ka-IZm">
+                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Accessory:" id="wNy-ka-IZm">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
It's properly spelled "accessory," not "accesory." See http://www.merriam-webster.com/dictionary/accessory