### PR TITLE
Add ordered list command

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1197,6 +1197,11 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     }
 }
 
+- (IBAction)toggleOrderedList:(id)sender
+{
+    [self.editor toggleBlockWithPattern:@"^[0-9]+ \\S" prefix:@"1. "];
+}
+
 - (IBAction)toggleUnorderedList:(id)sender
 {
     [self.editor toggleBlockWithPattern:@"^[\\*\\+-] \\S" prefix:@"* "];

--- a/MacDown/Localization/Base.lproj/MainMenu.xib
+++ b/MacDown/Localization/Base.lproj/MainMenu.xib
@@ -514,6 +514,11 @@
                                 </menu>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="tY3-Ap-TRo"/>
+                            <menuItem title="Ordered List" keyEquivalent="O" id="jn0-Kb-yH7">
+                                <connections>
+                                    <action selector="toggleOrderedList:" target="-1" id="K5g-7x-qoW"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Unordered List" keyEquivalent="U" id="jn0-Kb-yH6">
                                 <connections>
                                     <action selector="toggleUnorderedList:" target="-1" id="K5g-7x-qoV"/>


### PR DESCRIPTION
Based on the code for the unordered list. The command simply uses "1." as the prefix for the ordered lists, rather than worrying about counting.

I'm most uncertain about the IDs for the commands, which I created by modifying the last character of the IDs for the unordered versions. Likely there's a better method for generating them.