### PR TITLE
Always display latest version of file

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -418,15 +418,18 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
     [[NSOperationQueue mainQueue] addOperationWithBlock:^{
         [self setupEditor:nil];
         [self redrawDivider];
-
-        if (self.loadedString)
-        {
-            self.editor.string = self.loadedString;
-            self.loadedString = nil;
-            [self.renderer parseAndRenderNow];
-            [self.highlighter parseAndHighlightNow];
-        }
+        [self reloadString];
     }];
+}
+
+- (void)reloadString {
+    if (self.loadedString && self.editor && self.renderer && self.highlighter)
+    {
+        self.editor.string = self.loadedString;
+        self.loadedString = nil;
+        [self.renderer parseAndRenderNow];
+        [self.highlighter parseAndHighlightNow];
+    }
 }
 
 - (void)canCloseDocumentWithDelegate:(id)delegate
@@ -517,6 +520,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
         return NO;
 
     self.loadedString = content;
+    [self reloadString];
     return YES;
 }
 


### PR DESCRIPTION
This PR closes #559, closes #529, closes #349, closes #351, and closes #48. All of these issues are approximately duplicates of the same issue, which is that files modified by other applications aren't reflected in MacDown.

These changes are automatically passed to `[NSDocument -readFromData:ofType:error:]`. All this change does is update the display with the changes, rather than ignore them, which is what's happening now.

Here's how it looks with the new behavior:

![display-external-changes](https://cloud.githubusercontent.com/assets/789577/13135567/6499cfe8-d5d7-11e5-8a6a-745b686164dd.gif)

As a reminder, here's the old behavior, in which MacDown overwrites external changes without warning:

![old-behavior](https://cloud.githubusercontent.com/assets/789577/13135618/fd51db0e-d5d7-11e5-8ef9-fc073d28a75b.gif)
