### PR TITLE
Include .md extension when saving untitled files

### DIFF
--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -527,6 +527,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
 - (BOOL)prepareSavePanel:(NSSavePanel *)savePanel
 {
+    savePanel.extensionHidden = NO;
     NSString *fileName = self.presumedFileName;
     if (fileName && ![fileName hasExtension:@"md"])
     {
@@ -1542,7 +1543,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
     title = string.titleString;
     if (!title)
-        return nil;
+        return NSLocalizedString(@"untitled", @"default filename if no title can be determined");
 
     static NSRegularExpression *regex = nil;
     static dispatch_once_t onceToken;

--- a/MacDown/Code/Document/MPDocument.m
+++ b/MacDown/Code/Document/MPDocument.m
@@ -1543,7 +1543,7 @@ static void (^MPGetPreviewLoadingCompletionHandler(MPDocument *doc))()
 
     title = string.titleString;
     if (!title)
-        return NSLocalizedString(@"untitled", @"default filename if no title can be determined");
+        return NSLocalizedString(@"Untitled", @"default filename if no title can be determined");
 
     static NSRegularExpression *regex = nil;
     static dispatch_once_t onceToken;


### PR DESCRIPTION
Closes #557, and closes #497. `untitled.md` is used instead of the default `Untitled` when saving a new file.