### PR TITLE
Percent-escape macdown-cmd arguments

### DIFF
--- a/macdown-cmd/main.m
+++ b/macdown-cmd/main.m
@@ -61,7 +61,9 @@ int main(int argc, const char * argv[])
         NSMutableOrderedSet *urls = [NSMutableOrderedSet orderedSet];
         for (NSString *argument in argproc.arguments)
         {
-            NSURL *url = [NSURL URLWithString:argument relativeToURL:pwdUrl];
+            NSString *escapedArgument =
+                [argument stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+            NSURL *url = [NSURL URLWithString:escapedArgument relativeToURL:pwdUrl];
             [urls addObject:url.absoluteString];
         }
 


### PR DESCRIPTION
Fixes a crash when attempting to open files using `macdown-cmd` with URI reserved characters in the filename.